### PR TITLE
No checklist directory error handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ghqc
 Title: Manage QC via GitHub Issues using Shiny Apps
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Anne", "Zheng", email = "anne@a2-ai.com", role = c("aut")),
     person("Jenna", "Johnson", email = "jenna@a2-ai.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
-# ghqc (development version)
+# ghqc
 
-# ghqc 0.0.0.9001
+# ghqc 0.1.1
 
 ## Changes
 
--   Adds additional log messages providing information on state of session prior and after running ghqc.
+-   Bug fixes related to empty checklist folders and parsing GHQC_INFO_REPO out of the ~/.Renviron

--- a/R/checklist_validation.R
+++ b/R/checklist_validation.R
@@ -1,5 +1,6 @@
 #' @importFrom fs dir_ls
 validate_checklists <- function(info_path = ghqc_infopath()) {
+  if (!fs::dir_exists(file.path(info_path, "checklists"))) return(invisible())
   checklist_ls <- fs::dir_ls(file.path(info_path, "checklists"), regexp = "(.*?).yaml")
   lapply(checklist_ls, function(x) val_checklist(x))
 }

--- a/R/helper.R
+++ b/R/helper.R
@@ -9,7 +9,7 @@ error_checks <- function(app_name, qc_dir, lib_path, info_path) {
   if(!fs::dir_exists(qc_dir)) cli::cli_abort(paste(qc_dir, "does not exist."))
   if(!fs::dir_exists(lib_path)) cli::cli_abort(paste(lib_path, "does not exist. Refer to installation guide and check library path is set to correct location."))
   if(!(app_name) %in% c("ghqc_assign_app", "ghqc_resolve_app", "ghqc_record_app")) cli::cli_abort(paste(app_name, "not found in ghqc package."))
-  if(!fs::dir_exists(info_path)) cli::cli_abort(c("{info_path} does not exist.", "Run {.code ghqc::check_ghqc_configuration(info_path = {info_path})} to verify proper setup."))
+  if(!fs::dir_exists(info_path)) cli::cli_abort(c("{info_path} does not exist.", "Run {.code ghqc::check_ghqc_configuration(info_path = '{info_path}')} to verify proper setup."))
 }
 
 

--- a/R/helper.R
+++ b/R/helper.R
@@ -4,11 +4,12 @@ delete_bgj_script <- function(script) {
 }
 
 #' @importFrom fs dir_exists
+#' @importFrom cli cli_abort
 error_checks <- function(app_name, qc_dir, lib_path, info_path) {
-  if(!fs::dir_exists(qc_dir)) stop(paste(qc_dir, "does not exist."))
-  if(!fs::dir_exists(lib_path)) stop(paste(lib_path, "does not exist. Refer to installation guide and check library path is set to correct location."))
-  if(!(app_name) %in% c("ghqc_assign_app", "ghqc_resolve_app", "ghqc_record_app")) stop(paste(app_name, "not found in ghqc package."))
-  if(!fs::dir_exists(info_path)) stop(paste(info_path, "does not exist. Refer to installation guide and check information repo has been downloaded"))
+  if(!fs::dir_exists(qc_dir)) cli::cli_abort(paste(qc_dir, "does not exist."))
+  if(!fs::dir_exists(lib_path)) cli::cli_abort(paste(lib_path, "does not exist. Refer to installation guide and check library path is set to correct location."))
+  if(!(app_name) %in% c("ghqc_assign_app", "ghqc_resolve_app", "ghqc_record_app")) cli::cli_abort(paste(app_name, "not found in ghqc package."))
+  if(!fs::dir_exists(info_path)) cli::cli_abort(c("{info_path} does not exist.", "Run {.code ghqc::check_ghqc_configuration(info_path = {info_path})} to verify proper setup."))
 }
 
 

--- a/R/info_repo.R
+++ b/R/info_repo.R
@@ -161,7 +161,7 @@ info_files_desc <- function(info_path) {
   }
 
   if (fs::file_exists(repo_files[3])) {
-    if (length(fs::dir_ls(repo_files[3])) == 0) {
+    if (length(fs::dir_ls(file.path(info_path, "checklists"), regexp = "(.*?).yaml")) == 0) {
       cli::cli_alert_danger("Checklists directory is empty")
     } else {
       checklists_found(info_path)

--- a/R/info_repo.R
+++ b/R/info_repo.R
@@ -18,10 +18,11 @@ check_ghqc_configuration <- function(info_path = ghqc_infopath()) {
 #' Download the customizing information repository as set in environmental variable `GHQC_INFO_REPO`
 #'
 #' @param info_path *(optional)* path in which the repository, set in environmental variable `GHQC_INFO_REPO`, is, or should be, downloaded to. Defaults to `~/.local/share/ghqc/{repo_name}`
+#' @param .force *(optional)* option to force a new download of the ghqc configuration information repository
 #' @export
-download_ghqc_configuration <- function(info_path = ghqc_infopath()) {
+download_ghqc_configuration <- function(info_path = ghqc_infopath(), .force = FALSE) {
   check_ghqc_info_repo_exists()
-  switch(info_repo_status(info_path),
+  switch(info_repo_status(info_path, .force),
          "clone" = repo_clone(info_path),
          "update" = repo_clone(info_path),
          "none" = no_updates(info_path),
@@ -54,7 +55,8 @@ remove_ghqc_configuration <- function(info_path = ghqc_infopath()) {
 # local status check #
 #' @importFrom fs file_exists
 #' @importFrom rlang is_installed
-info_repo_status <- function(info_path) {
+info_repo_status <- function(info_path, .force = FALSE) {
+  if (.force) return("clone")
   if (!fs::file_exists(info_path)) return("clone")
   if (!rlang::is_installed("gert")) return("gert")
   if (remote_repo_updates(info_path)) return("update")
@@ -159,7 +161,7 @@ info_files_desc <- function(info_path) {
   }
 
   if (fs::file_exists(repo_files[3])) {
-    if (length(repo_files[3]) == 0) {
+    if (length(fs::dir_ls(repo_files[3])) == 0) {
       cli::cli_alert_danger("Checklists directory is empty")
     } else {
       checklists_found(info_path)

--- a/man/download_ghqc_configuration.Rd
+++ b/man/download_ghqc_configuration.Rd
@@ -4,10 +4,12 @@
 \alias{download_ghqc_configuration}
 \title{Download the customizing information repository as set in environmental variable \code{GHQC_INFO_REPO}}
 \usage{
-download_ghqc_configuration(info_path = ghqc_infopath())
+download_ghqc_configuration(info_path = ghqc_infopath(), .force = FALSE)
 }
 \arguments{
 \item{info_path}{\emph{(optional)} path in which the repository, set in environmental variable \code{GHQC_INFO_REPO}, is, or should be, downloaded to. Defaults to \verb{~/.local/share/ghqc/\{repo_name\}}}
+
+\item{.force}{\emph{(optional)} option to force a new download of the ghqc configuration information repository}
 }
 \description{
 Download the customizing information repository as set in environmental variable \code{GHQC_INFO_REPO}


### PR DESCRIPTION
A bug was found when attempting to clone a configuration information repository which did not contain a "checklist" directory due to an `fs::dir_ls()` call without checking if the directory exists before hand. Warning/communication if the checklist directory doesn't exist or is empty exists elsewhere in the code, so adding a verification step before listing the content within the directory helps to invoke that warning.

Additionally, creating a flag to force a new download of the configuration information repository within the `download_ghqc_information` function