### PR TITLE
Interactive setup typo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ghqc
 Title: Manage QC via GitHub Issues using Shiny Apps
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: c(
     person("Anne", "Zheng", email = "anne@a2-ai.com", role = c("aut")),
     person("Jenna", "Johnson", email = "jenna@a2-ai.com", role = c("aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ghqc
 Title: Manage QC via GitHub Issues using Shiny Apps
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: c(
     person("Anne", "Zheng", email = "anne@a2-ai.com", role = c("aut")),
     person("Jenna", "Johnson", email = "jenna@a2-ai.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ghqc
 
+# ghqc 0.1.6
+
+- typo found in `setup_ghqc` related to the info repo global variable. No performance change
+
 # ghqc 0.1.5
 
 - language change in `remove_ghqc_configuration` from "customizing information" to "custom configuration"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,3 @@
-# ghqc 0.1.6
-
-- remove version limits for dependencies. Tested version limits down to snapshot date of 2022-08-31
-- when using the `use_pak = FALSE` flag in `install_ghqcapp_dependencies`, forcing `utils::install.packages` to remove potential renv issues
-
 # ghqc 0.1.7
 
 - typo found in `setup_ghqc` related to the info repo global variable. No performance change

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,13 @@
 # ghqc
 
-# ghqc 0.1.6
+# ghqc 0.1.7
 
 - typo found in `setup_ghqc` related to the info repo global variable. No performance change
+
+# ghqc 0.1.6
+
+- remove version limits for dependencies. Tested version limits down to snapshot date of 2022-08-31
+- when using the `use_pak = FALSE` flag in `install_ghqcapp_dependencies`, forcing `utils::install.packages` to remove potential renv issues
 
 # ghqc 0.1.5
 

--- a/R/interactive_setup.R
+++ b/R/interactive_setup.R
@@ -32,7 +32,7 @@ interactive_info <- function(renv_text) {
     cli::cli_inform(c(" ", "GHQC_INFO_REPO is not set in your ~/.Renviron"))
     info_read <- readline("Provide the URL to the configuring information repository: ")
   } else {
-    cli::cli_inform(c(" ", "GITHUB_INFO_REPO is set to {info$val} in your ~/.Renviron"))
+    cli::cli_inform(c(" ", "GHQC_INFO_REPO is set to {info$val} in your ~/.Renviron"))
     info_read <- readline(glue::glue("Customizing Information Repository ({info$val}) "))
     if (info_read == "") info_read <- info$val
   }


### PR DESCRIPTION
found a reference to "GITHUB_INFO_REPO" not "GHQC_INFO_REPO". Updating for clarity and consistency