### PR TITLE
fixing bug which did not allow for gert to not be instaled

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ghqc
 Title: Manage QC via GitHub Issues using Shiny Apps
-Version: 0.1.7
+Version: 0.1.8
 Authors@R: c(
     person("Anne", "Zheng", email = "anne@a2-ai.com", role = c("aut")),
     person("Jenna", "Johnson", email = "jenna@a2-ai.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ghqc 0.1.8
+
+- The logic for rejecting `gert` install as part of `setup_ghqc` was incorrect. Updating to allow for rejection
+
 # ghqc 0.1.7
 
 - typo found in `setup_ghqc` related to the info repo global variable. No performance change

--- a/R/interactive_setup.R
+++ b/R/interactive_setup.R
@@ -63,7 +63,7 @@ interactive_info_download <- function() {
     cli::cli_inform(c("!" = "Package {.code gert} is not found in your project package library",
                       " " = "The configuration information repository cannot be downloaded unless this package is present"))
     yN <- gsub('\"', "", readline("Would you like to install `gert` to continue? (y/N) "))
-    if (yN != "y" && yN == "") {
+    if (yN != "y" || yN == "") {
       cli::cli_alert_danger("`gert` is not installed. Configuring information repository cannot be checked or downloaded using this package")
       return(invisible())
     }


### PR DESCRIPTION
Found an "and" statement instead of an "or" in regards to the apps response if a user does NOT want to install `gert`. In the current state, gert would force itself to install, independent of user response 